### PR TITLE
Makefile updated to use Rust 1.55.0 as the default version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER ?= docker
-RUST_VERSION ?= 1.54.0
+RUST_VERSION ?= 1.55.0
 REPO ?= rustserverless/lambda-rust
 
 publish: build


### PR DESCRIPTION
Updating for the new Rust version
- rustup update
- create branch for update
- update Makefile with new version
- make build
- make test
👌   15 tests passed.