### PR TITLE
Build and Publish Nightly Rust image

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,3 +35,4 @@ jobs:
       - run: gh issue create --title "Nightly publication failed" --body "Nightly publication failed" --label "bug" -R $GITHUB_REPOSITORY
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,7 @@ jobs:
         env:
           RUST_VERSION: nightly
           TAG: nightly
+          IMAGE: 'rustserverless/lambda-rust:nightly'
   publish:
     needs: [test]
     if: github.repository == 'rust-serverless/lambda-rust'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: Build Nightly Rust
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 3'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Build Nightly Rust
+      - run: make nightly
+  create_issue:
+    runs-on: ubuntu-latest
+    needs: check
+    if: always() && (needs.publish.result == 'failure')
+    steps:
+      - run: gh issue create --title "Nightly publication failed" --body "Nightly publication failed" --label "bug" -R $GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,15 +6,27 @@ on:
     - cron: '0 2 * * 3'
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        name: Build Nightly Rust
-      - run: make nightly
+      - run: make test
+        env:
+          RUST_VERSION: nightly
+          TAG: nightly
+  publish:
+    needs: [test]
+    if: github.repository == "rust-serverless/lambda-rust"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make publish
+        env:
+          RUST_VERSION: nightly
+          TAG: nightly
   create_issue:
     runs-on: ubuntu-latest
-    needs: check
+    needs: [publish]
     if: always() && (needs.publish.result == 'failure')
     steps:
       - run: gh issue create --title "Nightly publication failed" --body "Nightly publication failed" --label "bug" -R $GITHUB_REPOSITORY

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make test
+      - run: |
+             make build
+             make test
         env:
           RUST_VERSION: nightly
           TAG: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
           TAG: nightly
   publish:
     needs: [test]
-    if: github.repository == "rust-serverless/lambda-rust"
+    if: github.repository == 'rust-serverless/lambda-rust'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,17 @@ DOCKER ?= docker
 INPUT_RELEASE_VERSION ?= 0.4.0
 RUST_VERSION ?= 1.55.0
 REPO ?= rustserverless/lambda-rust
+TAG ?= latest
 
 publish: build
-	$(DOCKER) push $(REPO):latest
+	$(DOCKER) push $(REPO):${TAG}
 
 publish-tag: build publish
-	$(DOCKER) tag $(REPO):latest "$(REPO):$(INPUT_RELEASE_VERSION)-rust-$(RUST_VERSION)"
+	$(DOCKER) tag $(REPO):${TAG} "$(REPO):$(INPUT_RELEASE_VERSION)-rust-$(RUST_VERSION)"
 	$(DOCKER) push "$(REPO):$(INPUT_RELEASE_VERSION)-rust-$(RUST_VERSION)"
 
 build:
-	$(DOCKER) build --build-arg RUST_VERSION=$(RUST_VERSION) -t $(REPO):latest .
+	$(DOCKER) build --build-arg RUST_VERSION=$(RUST_VERSION) -t $(REPO):${TAG} .
 
 test:
 	@tests/test.sh
@@ -23,8 +24,4 @@ debug: build
 		-v ${HOME}/.cargo/registry:/cargo/registry \
 		-v ${HOME}/.cargo/git:/cargo/git  \
 		--entrypoint=/bin/bash \
-		$(REPO)
-
-nightly: 
-	$(DOCKER) build --build-arg RUST_VERSION=nightly -t $(REPO):nightly .
-	$(DOCKER) push $(REPO):nightly
+		$(REPO):$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ debug: build
 		-v ${HOME}/.cargo/git:/cargo/git  \
 		--entrypoint=/bin/bash \
 		$(REPO)
+
+nightly: 
+	$(DOCKER) build --build-arg RUST_VERSION=nightly -t $(REPO):nightly .
+	$(DOCKER) push $(REPO):nightly

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,7 +4,7 @@
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Root directory of the repository
 DIST=$(cd "$HERE"/..; pwd)
-IMAGE=${1:-rustserverless/lambda-rust}
+: "${IMAGE:=rustserverless/lambda-rust}"
 
 source "${HERE}"/bashtest.sh
 


### PR DESCRIPTION
## Objective
Build and publish Nightly rust container after Nightly Rust is built by the Rust Team. Tag the container "nightly"

## Add 

nightly.yml 
- Build and test using the Nightly Rust channel and tagging the container nightly
- On successful test build and publish Nightly Rust test
- On failure to publish create an issue
- action triggered each day 0200 UTC or manually if required

## Changes

### Make file 

- Parameter for the container tag that defaults to latest

### test.sh

- set IMAGE variable based on environment with default
