### PR TITLE
Build docker image before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ publish-tag: build publish
 build:
 	$(DOCKER) build --build-arg RUST_VERSION=$(RUST_VERSION) -t $(REPO):${TAG} .
 
-test:
+test: build
 	@tests/test.sh
 
 debug: build


### PR DESCRIPTION
By building the image before running tests, it'll use the build artifact rather than pulling down `latest` from Dockerhub

Closes #6 