### PR TITLE
Add autobuild to stable

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,35 @@
+name: Build Stable Rust
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 3'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+             make build
+             make test
+        env:
+          RUST_VERSION: stable
+  publish:
+    needs: [test]
+    if: github.repository == 'rust-serverless/lambda-rust'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make publish-tag
+        env:
+          RUST_VERSION: stable
+  create_issue:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    if: always() && (needs.publish.result == 'failure')
+    steps:
+      - run: gh issue create --title "Stable publication failed" --body "Stable publication failed" --label "bug" -R $GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          


### PR DESCRIPTION
Every Wednesday at 0200 UTC, this will build the rustup stable rust version and publish two images:


`rustserverless/lambda-rust:latest`
`rustserverless/lambda-rust:${INPUT_RELEASE_VERSION}-rust-stable`

Piggybacks on the work by @jerusdp to automatically create an issue if this fails.