### PR TITLE
Fix nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,8 +22,17 @@ jobs:
     if: github.repository == 'rust-serverless/lambda-rust'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: make publish
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with: 
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish
+        shell: bash
+        run: |
+          make publish-tag
         env:
           RUST_VERSION: nightly
           TAG: nightly
@@ -35,4 +44,3 @@ jobs:
       - run: gh issue create --title "Nightly publication failed" --body "Nightly publication failed" --label "bug" -R $GITHUB_REPOSITORY
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          


### PR DESCRIPTION
Fix for issue #12  

Publication requires docker credentials!

Docker credentials provided using the docker/login-action as this ensures that the credential data is not left on the runner after the run. 

@ZaMaZaN4iK 