### PR TITLE
Issue 13 dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG RUST_VERSION=1.54.0
 RUN yum install -y jq openssl-devel
 RUN set -o pipefail && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
-ADD build.sh /usr/local/bin/
-ADD latest.sh /usr/local/bin/
+COPY build.sh /usr/local/bin/
+COPY latest.sh /usr/local/bin/
 VOLUME ["/code"]
 WORKDIR /code
 ENTRYPOINT ["/usr/local/bin/build.sh"]


### PR DESCRIPTION
Issue #13 
Updated Dockerfile to use AWS Lambda docker from the AWS public ecr repository.

This base offers the following advantages:
- actively updated by Amazon
- supports both x86 and arm (Graviton2) processors

Two additional changes in Dockerfile based on recommended best practices
- set -0 pipefail on curl and build to ensure that there isn't "false success"
- COPY instead of ADD as we are only copying the files

@ZaMaZaN4iK 