### PR TITLE
feat: update to Rust 1.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0-rust-1.56.1
+
+* Upgrade to Rust [`1.56.1`](https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html)
+
 # 0.4.0-rust-1.56.0
 
 * Upgrade to Rust [`1.56.0`](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/lambda/provided:al2
 
-ARG RUST_VERSION=1.56.0
+ARG RUST_VERSION=1.56.1
 RUN yum install -y jq openssl-devel gcc zip
 RUN set -o pipefail && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER ?= docker
 INPUT_RELEASE_VERSION ?= 0.4.0
-RUST_VERSION ?= 1.56.0
+RUST_VERSION ?= 1.56.1
 REPO ?= rustserverless/lambda-rust
 TAG ?= latest
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 ## 🤔 about
 
-This docker image extends [lambda ci `provided.al2`](https://github.com/lambci/docker-lambda#documentation) builder docker image, a faithful reproduction of the actual AWS "**provided.al2**" Lambda runtime environment,
-and installs [rustup](https://rustup.rs/) and the *stable* rust toolchain.
+This docker image extends AWS Lambda `provided.al2 runtime environment, and installs [rustup](https://rustup.rs/) and the *stable* rust toolchain.
 
 This provides a build environment, consistent with your target execution environment for predictable results.
 
@@ -108,7 +107,7 @@ output (not zipped) is available under `target/lambda/{profile}/output/{your-lam
 You will see both `bootstrap` and `bootstrap.debug` files there.
 > **⚠️ Note:** `PACKAGE=false` prevents `package` hook from running.
 
-You can then invoke this bootstap executable with the lambda-ci docker image for the `provided.al2` AWS lambda runtime with a one off container.
+You can then invoke this bootstap executable for the `provided.al2` AWS lambda runtime with a one off container.
 
 ```sh
 # Build your function skipping the zip creation step
@@ -128,7 +127,7 @@ $ docker run \
     -i -e DOCKER_LAMBDA_USE_STDIN=1 \
     --rm \
     -v ${PWD}/target/lambda/release/output/{your-binary-name}:/var/task:ro,delegated \
-    lambci/lambda:provided.al2
+    public.ecr.aws/lambda/provided:al2
 
 # provide an event payload via stdin (typically a json blob)
 
@@ -148,7 +147,7 @@ $ unzip -o \
     -v /tmp/lambda:/var/task:ro,delegated \
     -e DOCKER_LAMBDA_STAY_OPEN=1 \
     -p 9001:9001 \
-    lambci/lambda:provided.al2
+    public.ecr.aws/lambda/provided:al2
 ```
 
 In a separate terminal, you can invoke your function with `curl`


### PR DESCRIPTION
- update to Rust 1.56.1 version
- update README: get rid of redundant lamb ci references

Tested:
- No