### PR TITLE
fix(actions): 🐛 ECR rate limiting

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Build Nightly Rust
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * 3'
+    - cron: '0 4 * * 3'
 
 jobs:
   test:


### PR DESCRIPTION
Change time nightly action fires as clashes with stable to fix #30.

AWS ECR is rated to ,limited to 1 when no AWS account is signed in. Both the Nightly and Stable actions fire at the same time 0200.

I have changed Nightly to fire at 0400. 

@zamazan4ik 