### PR TITLE
feat(rust): Update rust version to 1.76.0 (arm64)

### DIFF
--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/lambda/provided:al2-arm64
 
-ARG RUST_VERSION=1.65.0
+ARG RUST_VERSION=1.76.0
 RUN yum install -y jq openssl-devel gcc zip
 RUN set -o pipefail && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION


### PR DESCRIPTION
Follow up https://github.com/rust-serverless/lambda-rust/pull/51

We need to update arm64 image, not only x86_64 one.